### PR TITLE
Harden against argument-less commands

### DIFF
--- a/src/back/parser.cpp
+++ b/src/back/parser.cpp
@@ -90,18 +90,23 @@ Command Parser::parseCommand(std::string command) {
     }
     else if (commandPart == "select") {
         //select has only one argument, stick it in line and ignore the rest
-        parsedCommand.argumentPart.push_back(argumentPart.front());
+        if (!argumentPart.empty()) {
+            parsedCommand.argumentPart.push_back(argumentPart.front());
+        } else {
+            parsedCommand.argumentPart.push_back("");
+        }
         parsedCommand.commandPart = cmdSelect;
     }
     else if (commandPart == "list") {
-        if(argumentPart.front() == "bibles" ||
+        if(!argumentPart.empty() &&
+          (argumentPart.front() == "bibles" ||
            argumentPart.front() == "commentaries" ||
            argumentPart.front() == "devotions" ||
            argumentPart.front() == "books" ||
            argumentPart.front() == "dictionaries" ||
            argumentPart.front() == "lexicons" ||
            argumentPart.front() == "unorthodox" ||
-           argumentPart.front() == "glossaries") {
+           argumentPart.front() == "glossaries")) {
 
             parsedCommand.argumentPart.push_back(argumentPart.front());
         }
@@ -155,7 +160,11 @@ Command Parser::parseCommand(std::string command) {
         std::string word;
 
         //Take the first "token" as the word and ignore everything else
-        word = argumentPart.front();
+        if(!argumentPart.empty()) {
+            word = argumentPart.front();
+        } else {
+            word = "";
+        }
 
         parsedCommand.commandPart = cmdGloss;
 

--- a/src/front/interface.cpp
+++ b/src/front/interface.cpp
@@ -382,6 +382,14 @@ void Interface::commandDevo(Command parsedCommand) {
     std::list<page> devotionPages;
     std::string devotionText;
 
+    if(this->selectedVersion == "") {
+        this->display.displayHeader();
+        this->display.displaySpacer(1);
+        std::cerr << "No module selected. Try Select";
+        std::cerr << std::endl;
+        return;
+    }
+
     this->library.devotion.setDevotion(this->selectedVersion);
 
     devotionText = this->library.devotion.getDevo( \
@@ -399,6 +407,14 @@ void Interface::commandGloss(Command parsedCommand) {
     std::list<Page> glossPages;
     std::string word;
     std::string glossEntry;
+
+    if(this->selectedVersion == "") {
+        this->display.displayHeader();
+        this->display.displaySpacer(1);
+        std::cerr << "No module selected. Try Select";
+        std::cerr << std::endl;
+        return;
+    }
 
     this->library.glossary.setGlossary(this->selectedVersion);
 


### PR DESCRIPTION
Fixes https://github.com/JudahsShadow/bibish/issues/7.

I'm not entirely sure I have the UI right for the `devo` and `gloss` commands - I simply grapped the "no module selected" code from the `read` command and dropped it in where it was useful.